### PR TITLE
Update _config.yml for license in footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,10 @@ repository:
 
 html:
   use_respository_button: true
+  extra_footer: |
+    <p>
+    &copy; 2024 -- This work is licensed under Creative Commons Attribution Share Alike 4.0 International (CC-BY-SA) <br>
+    </p>
 
 bibtex_bibfiles:
     - guidebook_references.bib


### PR DESCRIPTION
Please also fix the license info on the landing page of the Jupyter Book, which currently lists two different licenses.